### PR TITLE
Documents work around AWS ElastiCacheMasterReplicationTimestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Supports single servers, Sentinel and Redis cluster.
 </infinispan>
 ```
 
+## Caveats
+
+* When using AWS ElastiCache, always specify an explicit non-zero database index for all `<redis-store/>` configurations, for example `<redis-store database="1"/>`. AWS ElastiCache inserts a special *ElastiCacheMasterReplicationTimestamp* key in the default database (at zero index) to aid replication, which may lead to unexpected unmarshalling IO exceptions when the Infinispan cache needs to iterate over the stored keys.
 
 
 ## License


### PR DESCRIPTION
Documents a work around when using the Redis Cache Store with AWS ElastiCache, where AWS inserts a special ElastiCacheMasterReplicationTimestamp key into the default Redis database, which may lead to unexpected unmarshalling exceptions.
