### PR TITLE
Fixes parsing of top-level inherited XML attributes (iss #4)

### DIFF
--- a/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
+++ b/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
@@ -225,6 +225,11 @@ final public class RedisStoreConfigurationParser80 implements ConfigurationParse
                     builder.maxRedirections(Integer.parseInt(value));
                     break;
                 }
+    
+                default: {
+                    Parser80.parseStoreAttribute(reader, i, builder);
+                    break;
+                }
             }
         }
     }

--- a/src/test/java/org/infinispan/persistence/redis/configuration/XmlFileParsingTest.java
+++ b/src/test/java/org/infinispan/persistence/redis/configuration/XmlFileParsingTest.java
@@ -36,6 +36,27 @@ public class XmlFileParsingTest extends AbstractInfinispanTest
         assert store.servers().size() == 2;
     }
 
+    public void testInheritedCacheStoreAttributes() throws Exception
+    {
+        String config = InfinispanStartTag.LATEST +
+            "<cache-container default-cache=\"default\">" +
+            "   <local-cache name=\"default\">\n" +
+            "     <persistence>\n" +
+            "       <redis-store xmlns=\"urn:infinispan:config:store:redis:"+ InfinispanStartTag.LATEST.majorMinor()+ "\"" +
+            "             shared=\"true\" preload=\"true\" >\n" +
+            "         <redis-server host=\"one\" />\n" +
+            "       </redis-store>\n" +
+            "     </persistence>\n" +
+            "   </local-cache>\n" +
+            "</cache-container>" +
+            TestingUtil.INFINISPAN_END_TAG;
+
+        RedisStoreConfiguration store = (RedisStoreConfiguration) buildCacheManagerWithCacheStore(config);
+        assert store.shared();
+        assert store.preload();
+        assert store.servers().size() == 1;
+    }
+
     private StoreConfiguration buildCacheManagerWithCacheStore(final String config)
         throws IOException
     {


### PR DESCRIPTION
This fixes the missing parsing of the top-level XML attributes inherited by redis-store from cache-store.

All tests pass.

Cheers,
Vladimir