### PR TITLE
Bumps Infinispan to 8.2.3 (iss #12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     </distributionManagement>
 
     <properties>
-        <infinispan.core.schema.version>8.0</infinispan.core.schema.version>
+        <infinispan.core.schema.version>8.2</infinispan.core.schema.version>
         <version.testng>6.8.8</version.testng>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>8.0.0.Final</version>
+            <version>8.2.3.Final</version>
         </dependency>
 
         <dependency>
@@ -256,7 +256,7 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>8.0.0.Final</version>
+            <version>8.2.3.Final</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/infinispan/persistence/redis/RedisStore.java
+++ b/src/main/java/org/infinispan/persistence/redis/RedisStore.java
@@ -37,7 +37,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void init(InitializationContext ctx)
     {
-        RedisStore.log.info("Redis cache store initialising");
+        RedisStore.log.info("Initialising Redis store for cache " + ctx.getCache().getName());
         this.ctx = ctx;
     }
 
@@ -47,13 +47,13 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void start()
     {
-        RedisStore.log.info("Redis cache store starting");
+        RedisStore.log.info("Starting Redis store for cache " + ctx.getCache().getName());
 
         try {
             this.connectionPool = RedisConnectionPoolFactory.factory(this.ctx.getConfiguration(), this.ctx.getMarshaller());
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to initialise the redis store", ex);
+            RedisStore.log.error("Failed to initialise the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
     }
@@ -64,7 +64,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void stop()
     {
-        RedisStore.log.info("Redis cache store stopping");
+        RedisStore.log.info("Stopping Redis store for cache " + ctx.getCache().getName());
 
         if (null != this.connectionPool) {
             this.connectionPool.shutdown();
@@ -101,7 +101,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
         boolean fetchMetadata
     )
     {
-        RedisStore.log.debug("Iterating Redis store entries");
+        RedisStore.log.debug("Iterating Redis store entries for cache " + ctx.getCache().getName());
 
         final InitializationContext ctx = this.ctx;
         final TaskContext taskContext = new TaskContextImpl();
@@ -137,7 +137,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
                             }
                         }
                         catch (Exception ex) {
-                            RedisStore.log.error("Failed to process the redis store key", ex);
+                            RedisStore.log.error("Failed to process a Redis store key for cache " + ctx.getCache().getName(), ex);
                             throw new PersistenceException(ex);
                         }
                     }
@@ -145,7 +145,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to process the redis store keys", ex);
+            RedisStore.log.error("Failed to process the Redis store keys for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -175,7 +175,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public int size()
     {
-        RedisStore.log.debug("Calculating Redis store size");
+        RedisStore.log.debug("Fetching the Redis store size for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -187,9 +187,9 @@ final public class RedisStore implements AdvancedLoadWriteStore
             // log the anomaly and return the int max size
             if (dbSize > Integer.MAX_VALUE) {
                 RedisStore.log.info(
-                    String.format("Redis store is holding more elements than we can count! " +
-                            "Total number of elements found %d. Limited to returning count as %d",
-                        dbSize, Integer.MAX_VALUE
+                    String.format("The Redis store for cache %s is holding more entries than we can count! " +
+                            "Total number of entries found %d. Limited to returning count as %d",
+                        ctx.getCache().getName(), dbSize, Integer.MAX_VALUE
                     )
                 );
 
@@ -200,7 +200,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to fetch element count from the redis store", ex);
+            RedisStore.log.error("Failed to fetch the entry count for the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -218,7 +218,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void clear()
     {
-        RedisStore.log.debug("Clearing Redis store");
+        RedisStore.log.debug("Clearing the Redis store for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -226,7 +226,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             connection.flushDb();
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to clear all elements in the redis store", ex);
+            RedisStore.log.error("Failed to clear the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -247,7 +247,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public MarshalledEntry load(Object key)
     {
-        RedisStore.log.debug("Loading entry from Redis store");
+        RedisStore.log.debug("Loading entry from the Redis store for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -270,7 +270,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return this.ctx.getMarshalledEntryFactory().newMarshalledEntry(key, valueBuf, metadataBuf);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to load element from the redis store", ex);
+            RedisStore.log.error("Failed to load entry from the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -289,7 +289,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void write(MarshalledEntry marshalledEntry)
     {
-        RedisStore.log.debug("Writing entry to Redis store");
+        RedisStore.log.debug("Writing entry to the Redis store for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -317,7 +317,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to write element to the redis store", ex);
+            RedisStore.log.error("Failed to write entry to the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -336,7 +336,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public boolean delete(Object key)
     {
-        RedisStore.log.debug("Deleting entry from Redis store");
+        RedisStore.log.debug("Deleting entry from Redis store for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -344,7 +344,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return connection.delete(key);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to delete element from the redis store", ex);
+            RedisStore.log.error("Failed to delete entry from the Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {
@@ -363,7 +363,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public boolean contains(Object key)
     {
-        RedisStore.log.debug("Checking store for Redis entry");
+        RedisStore.log.debug("Checking key in Redis store for cache " + ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -371,7 +371,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return connection.exists(key);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to discover if element is in the redis store", ex);
+            RedisStore.log.error("Failed to check key in Redis store for cache " + ctx.getCache().getName(), ex);
             throw new PersistenceException(ex);
         }
         finally {

--- a/src/main/java/org/infinispan/persistence/redis/RedisStore.java
+++ b/src/main/java/org/infinispan/persistence/redis/RedisStore.java
@@ -51,7 +51,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void init(InitializationContext ctx)
     {
-        RedisStore.log.info("Initialising Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.infof("Initialising Redis store for cache '%s'", ctx.getCache().getName());
         this.ctx = ctx;
     
         // Register store
@@ -66,13 +66,13 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void start()
     {
-        RedisStore.log.info("Starting Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.infof("Starting Redis store for cache '%s'", ctx.getCache().getName());
 
         try {
             this.connectionPool = RedisConnectionPoolFactory.factory(this.ctx.getConfiguration(), this.ctx.getMarshaller());
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to initialise the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex, "Failed to initialise the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
     }
@@ -83,7 +83,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void stop()
     {
-        RedisStore.log.info("Stopping Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.infof("Stopping Redis store for cache '%s'", ctx.getCache().getName());
 
         if (null != this.connectionPool) {
             this.connectionPool.shutdown();
@@ -125,7 +125,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
         boolean fetchMetadata
     )
     {
-        RedisStore.log.debug("Iterating Redis store entries for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Iterating Redis store entries for cache '%s'", ctx.getCache().getName());
 
         final InitializationContext ctx = this.ctx;
         final TaskContext taskContext = new TaskContextImpl();
@@ -161,7 +161,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
                             }
                         }
                         catch (Exception ex) {
-                            RedisStore.log.error("Failed to process a Redis store key for cache " + ctx.getCache().getName(), ex);
+                            RedisStore.log.errorf(ex, "Failed to process a Redis store key for cache '%s'", ctx.getCache().getName());
                             throw new PersistenceException(ex);
                         }
                     }
@@ -169,7 +169,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to process the Redis store keys for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex, "Failed to process the Redis store keys for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -199,7 +199,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public int size()
     {
-        RedisStore.log.debug("Fetching the Redis store size for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Fetching the Redis store size for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -210,11 +210,9 @@ final public class RedisStore implements AdvancedLoadWriteStore
             // If the number of elements in redis is more than the int max size,
             // log the anomaly and return the int max size
             if (dbSize > Integer.MAX_VALUE) {
-                RedisStore.log.warn(
-                    String.format("The Redis store for cache %s is holding more entries than we can count! " +
-                            "Total number of entries found %d. Limited to returning count as %d",
+                RedisStore.log.warnf("The Redis store for cache '%s' is holding more entries than we can count! " +
+                        "Total number of entries found %d. Limited to returning count as %d",
                         ctx.getCache().getName(), dbSize, Integer.MAX_VALUE
-                    )
                 );
 
                 return Integer.MAX_VALUE;
@@ -224,7 +222,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to fetch the entry count for the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex, "Failed to fetch the entry count for the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -242,7 +240,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void clear()
     {
-        RedisStore.log.debug("Clearing the Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Clearing the Redis store for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -250,7 +248,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             connection.flushDb();
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to clear the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex, "Failed to clear the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -271,7 +269,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public MarshalledEntry load(Object key)
     {
-        RedisStore.log.debug("Loading entry from the Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Loading entry from the Redis store for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -294,7 +292,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return this.ctx.getMarshalledEntryFactory().newMarshalledEntry(key, valueBuf, metadataBuf);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to load entry from the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex, "Failed to load entry from the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -313,7 +311,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public void write(MarshalledEntry marshalledEntry)
     {
-        RedisStore.log.debug("Writing entry to the Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Writing entry to the Redis store for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -341,7 +339,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             }
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to write entry to the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex,"Failed to write entry to the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -360,7 +358,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public boolean delete(Object key)
     {
-        RedisStore.log.debug("Deleting entry from Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Deleting entry from Redis store for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -368,7 +366,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return connection.delete(key);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to delete entry from the Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex,"Failed to delete entry from the Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {
@@ -387,7 +385,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     @Override
     public boolean contains(Object key)
     {
-        RedisStore.log.debug("Checking key in Redis store for cache " + ctx.getCache().getName());
+        RedisStore.log.debugf("Checking key in Redis store for cache '%s'", ctx.getCache().getName());
         RedisConnection connection = null;
 
         try {
@@ -395,7 +393,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             return connection.exists(key);
         }
         catch(Exception ex) {
-            RedisStore.log.error("Failed to check key in Redis store for cache " + ctx.getCache().getName(), ex);
+            RedisStore.log.errorf(ex,"Failed to check key in Redis store for cache '%s'", ctx.getCache().getName());
             throw new PersistenceException(ex);
         }
         finally {

--- a/src/main/java/org/infinispan/persistence/redis/RedisStore.java
+++ b/src/main/java/org/infinispan/persistence/redis/RedisStore.java
@@ -24,7 +24,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
     /**
      * The instances of this class, keyed by Infinispan cache name.
      */
-    private static Map<String,RedisStore> instances = new Hashtable<>();
+    private static Map<String, RedisStore> instances = new Hashtable<>();
     
     
     /**
@@ -33,7 +33,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
      * @return The instances of this class as an unmodifiable map, keyed by
      *         Infinispan cache name.
      */
-    public static Map<String,RedisStore> getInstances() {
+    public static Map<String, RedisStore> getInstances() {
         return Collections.unmodifiableMap(instances);
     }
     

--- a/src/main/java/org/infinispan/persistence/redis/RedisStore.java
+++ b/src/main/java/org/infinispan/persistence/redis/RedisStore.java
@@ -186,7 +186,7 @@ final public class RedisStore implements AdvancedLoadWriteStore
             // If the number of elements in redis is more than the int max size,
             // log the anomaly and return the int max size
             if (dbSize > Integer.MAX_VALUE) {
-                RedisStore.log.info(
+                RedisStore.log.warn(
                     String.format("The Redis store for cache %s is holding more entries than we can count! " +
                             "Total number of entries found %d. Limited to returning count as %d",
                         ctx.getCache().getName(), dbSize, Integer.MAX_VALUE

--- a/src/main/java/org/infinispan/persistence/redis/client/RedisServerConnectionPool.java
+++ b/src/main/java/org/infinispan/persistence/redis/client/RedisServerConnectionPool.java
@@ -30,8 +30,8 @@ final public class RedisServerConnectionPool implements RedisConnectionPool
         server = servers.get(0);
 
         if (servers.size() > 1) {
-            RedisServerConnectionPool.log.warn(String.format("Multiple redis servers defined. Using the first only (%s:%d)",
-                server.host(), server.port()));
+            RedisServerConnectionPool.log.warnf("Multiple redis servers defined. Using the first only (%s:%d)",
+                server.host(), server.port());
         }
 
         ConnectionPoolConfiguration connectionPoolConfiguration = configuration.connectionPool();

--- a/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
+++ b/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
@@ -225,6 +225,11 @@ final public class RedisStoreConfigurationParser80 implements ConfigurationParse
                     builder.maxRedirections(Integer.parseInt(value));
                     break;
                 }
+    
+                default: {
+                    Parser80.parseStoreAttribute(reader, i, builder);
+                    break;
+                }
             }
         }
     }

--- a/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
+++ b/src/main/java/org/infinispan/persistence/redis/configuration/RedisStoreConfigurationParser80.java
@@ -227,7 +227,7 @@ final public class RedisStoreConfigurationParser80 implements ConfigurationParse
                 }
     
                 default: {
-                    Parser80.parseStoreAttribute(reader, i, builder);
+                    Parser.parseStoreAttribute(reader, i, builder);
                     break;
                 }
             }

--- a/src/test/java/org/infinispan/persistence/redis/RedisServerStoreFunctionalTest.java
+++ b/src/test/java/org/infinispan/persistence/redis/RedisServerStoreFunctionalTest.java
@@ -99,4 +99,42 @@ public class RedisServerStoreFunctionalTest extends BaseStoreFunctionalTest
         Assert.assertEquals("val2", this.unwrap(second.get("key2")));
         Assert.assertNull(first.get("key2"));
     }
+    
+    public void testGetRedisStoreInstance()
+    {
+        ConfigurationBuilder cb1 = new ConfigurationBuilder();
+        cb1.read(this.cacheManager.getDefaultCacheConfiguration());
+        this.createCacheStoreConfig(cb1.persistence(), false, 0);
+        Configuration c1 = cb1.build();
+    
+        ConfigurationBuilder cb2 = new ConfigurationBuilder();
+        cb2.read(this.cacheManager.getDefaultCacheConfiguration());
+        this.createCacheStoreConfig(cb2.persistence(), false, 1);
+        Configuration c2 = cb2.build();
+    
+        Assert.assertTrue(RedisStore.getInstances().isEmpty());
+        
+        this.cacheManager.defineConfiguration("testTwoCachesSameCacheStore-1", c1);
+        this.cacheManager.defineConfiguration("testTwoCachesSameCacheStore-2", c2);
+        Cache first = this.cacheManager.getCache("testTwoCachesSameCacheStore-1");
+        Cache second = this.cacheManager.getCache("testTwoCachesSameCacheStore-2");
+    
+        first.start();
+        second.start();
+        
+        RedisStore firstRedisStore = RedisStore.getInstances().get("testTwoCachesSameCacheStore-1");
+        RedisStore secondRedisStore = RedisStore.getInstances().get("testTwoCachesSameCacheStore-2");
+        Assert.assertEquals(2, RedisStore.getInstances().size());
+        
+        first.put("key1", "val2");
+        second.put("key2", "val2");
+    
+        Assert.assertTrue(firstRedisStore.contains("key1"));
+        Assert.assertTrue(secondRedisStore.contains("key2"));
+        
+        first.stop();
+        second.stop();
+        
+        Assert.assertTrue(RedisStore.getInstances().isEmpty());
+    }
 }

--- a/src/test/java/org/infinispan/persistence/redis/RedisServerStoreFunctionalTest.java
+++ b/src/test/java/org/infinispan/persistence/redis/RedisServerStoreFunctionalTest.java
@@ -112,7 +112,7 @@ public class RedisServerStoreFunctionalTest extends BaseStoreFunctionalTest
         this.createCacheStoreConfig(cb2.persistence(), false, 1);
         Configuration c2 = cb2.build();
     
-        Assert.assertTrue(RedisStore.getInstances().isEmpty());
+        int initialNumRedisStoreInstances = RedisStore.getInstances().size();
         
         this.cacheManager.defineConfiguration("testTwoCachesSameCacheStore-1", c1);
         this.cacheManager.defineConfiguration("testTwoCachesSameCacheStore-2", c2);
@@ -124,7 +124,7 @@ public class RedisServerStoreFunctionalTest extends BaseStoreFunctionalTest
         
         RedisStore firstRedisStore = RedisStore.getInstances().get("testTwoCachesSameCacheStore-1");
         RedisStore secondRedisStore = RedisStore.getInstances().get("testTwoCachesSameCacheStore-2");
-        Assert.assertEquals(2, RedisStore.getInstances().size());
+        Assert.assertEquals(initialNumRedisStoreInstances + 2, RedisStore.getInstances().size());
         
         first.put("key1", "val2");
         second.put("key2", "val2");
@@ -135,6 +135,8 @@ public class RedisServerStoreFunctionalTest extends BaseStoreFunctionalTest
         first.stop();
         second.stop();
         
-        Assert.assertTrue(RedisStore.getInstances().isEmpty());
+        Assert.assertNull(RedisStore.getInstances().get("testTwoCachesSameCacheStore-1"));
+        Assert.assertNull(RedisStore.getInstances().get("testTwoCachesSameCacheStore-2"));
+        Assert.assertEquals(initialNumRedisStoreInstances, RedisStore.getInstances().size());
     }
 }

--- a/src/test/java/org/infinispan/persistence/redis/configuration/XmlFileParsingTest.java
+++ b/src/test/java/org/infinispan/persistence/redis/configuration/XmlFileParsingTest.java
@@ -36,6 +36,27 @@ public class XmlFileParsingTest extends AbstractInfinispanTest
         assert store.servers().size() == 2;
     }
 
+    public void testInheritedCacheStoreAttributes() throws Exception
+    {
+        String config = InfinispanStartTag.LATEST +
+            "<cache-container default-cache=\"default\">" +
+            "   <local-cache name=\"default\">\n" +
+            "     <persistence>\n" +
+            "       <redis-store xmlns=\"urn:infinispan:config:store:redis:"+ InfinispanStartTag.LATEST.majorMinor()+ "\"" +
+            "             shared=\"true\" preload=\"true\" >\n" +
+            "         <redis-server host=\"one\" />\n" +
+            "       </redis-store>\n" +
+            "     </persistence>\n" +
+            "   </local-cache>\n" +
+            "</cache-container>" +
+            TestingUtil.INFINISPAN_END_TAG;
+
+        RedisStoreConfiguration store = (RedisStoreConfiguration) buildCacheManagerWithCacheStore(config);
+        assert store.shared();
+        assert store.preload();
+        assert store.servers().size() == 1;
+    }
+
     private StoreConfiguration buildCacheManagerWithCacheStore(final String config)
         throws IOException
     {


### PR DESCRIPTION
Bumps Infinispan to 8.3.2 to use org.infinispan.configuration.parsing.Parser instead of Parser80.

Not sure if the schema should be bumped as well? org.infinispan.test.TestingUtil doesn't include 8.2 as valid schema version.